### PR TITLE
fix: add describe blocks for testing and get rid of total_games method

### DIFF
--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -6,7 +6,7 @@ require_relative 'game_stats'
 
 class StatTracker
   include TeamStatistics
-  include LeagueStatistics 
+  include LeagueStatistics
   include SeasonStatistics
   include GameStats
 
@@ -25,11 +25,6 @@ class StatTracker
     teams = CSV.read locations[:teams], headers: true, header_converters: :symbol
     game_teams = CSV.read locations[:game_teams], headers: true, header_converters: :symbol
     StatTracker.new(games, teams, game_teams)
-  end
-
-
-  def total_games
-    @games.count
   end
 
   def team_name(team_id)

--- a/spec/season_stats_spec.rb
+++ b/spec/season_stats_spec.rb
@@ -1,6 +1,5 @@
 # require 'rspec'
 require './lib/season_stats'
-require './lib/stat_tracker'
 
 
 RSpec.describe SeasonStatistics do
@@ -16,7 +15,7 @@ RSpec.describe SeasonStatistics do
     }
     @stat_tracker = StatTracker.from_csv(locations)
   end
-  
+
   describe '#find_season' do
     it 'returns the relevant games based on the season' do
       expect(@stat_tracker.find_season('20122013').first).to be_a(CSV::Row)
@@ -24,19 +23,19 @@ RSpec.describe SeasonStatistics do
       expect(@stat_tracker.find_season('20102011')).to eq([])
     end
   end
-  
+
   describe '#total_goals(season)' do
     it 'returns a hash containing key value pair of team_id and total goals for that team' do
       expect(@stat_tracker.total_goals('20122013')).to eq({"17"=>6.0, "16"=>2.0})
     end
   end
-  
+
   describe '#total_shots(season)' do
     it 'returns a hash containing key value pair of team_id and total shots for that team' do
       expect(@stat_tracker.total_shots('20122013')).to eq({"17"=>19.0, "16"=>18.0})
     end
   end
-  
+
   describe '#most_accurate_team(season)' do
     it 'returns the team that made the most accurate shots over the season' do
       expect(@stat_tracker.most_accurate_team('20142015')).to eq('New York Red Bulls')
@@ -48,31 +47,31 @@ RSpec.describe SeasonStatistics do
       expect(@stat_tracker.least_accurate_team('20142015')).to eq('New York City FC')
     end
   end
-  
+
   describe '#total_games_played_per_team(season)' do
     it 'returns a hash containing a key value pair of coach and number of games' do
       expect(@stat_tracker.total_games_played_per_team("20122013")).to eq({"Mike Babcock"=>3, "Joel Quenneville"=>2})
     end
   end
-  
+
   describe '#total_wins_per_team(season)' do
     it 'returns a hash containing a key value pair of coach and number of wins' do
       expect(@stat_tracker.total_wins_per_team('20122013')).to eq({"Mike Babcock"=>2, "Joel Quenneville"=>1})
     end
   end
-  
+
   describe '#winningest_coach(season)' do
     it 'returns the name of the coach with the best win record over a given season' do
       expect(@stat_tracker.winningest_coach('20122013')).to eq("Mike Babcock")
     end
   end
-    
+
   describe '#worst_coach(season)' do
     it 'returns the name of the coach with the worst win record over a given season' do
       expect(@stat_tracker.worst_coach('20122013')).to eq("Joel Quenneville")
     end
   end
-  
+
   describe "#most_tackles" do
     it 'returns the name of the team with the most tackles in a given season' do
       expect(@stat_tracker.most_tackles("20122013")).to eq "LA Galaxy"
@@ -86,5 +85,5 @@ RSpec.describe SeasonStatistics do
       expect(@stat_tracker.fewest_tackles("20142015")).to eq "New York City FC"
     end
   end
-  
+
 end

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -15,12 +15,17 @@ RSpec.describe StatTracker do
     @stat_tracker = StatTracker.from_csv(locations)
   end
 
-  it 'exists' do
-    expect(@stat_tracker).to be_a(StatTracker)
+  describe '#initialize' do
+    it 'exists' do
+      expect(@stat_tracker).to be_a(StatTracker)
+    end
   end
 
-  it '#total_games' do
-    expect(@stat_tracker.total_games).to eq(9)
+  describe '#team_name' do
+    it 'take in a team_id and returns the team name' do
+      expect(@stat_tracker.team_name(6)).to eq('FC Dallas')
+      expect(@stat_tracker.team_name(3)).to eq('Houston Dynamo')
+    end
   end
 
 end


### PR DESCRIPTION
added describe blocks for our stat_tracker testing and got rid of our total_games method since we weren't using it